### PR TITLE
Mobile用メニューをOpenしたときの不具合を修正

### DIFF
--- a/src/components/Layout.module.scss
+++ b/src/components/Layout.module.scss
@@ -29,7 +29,7 @@
   z-index: 1000;
   &__menuOpen {
     display: block;
-    top: 64px;
+    top: calc(50% - 36px);
     left: 0;
     right: 0;
   }
@@ -176,6 +176,7 @@
     padding: 40px 5vw;
     &__menuOpen {
       padding: 0;
+      top: calc(50% - 158px);
     }
   }
   .filterLayer {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -30,7 +30,10 @@ const Layout = ({ children }: { children: ReactNode }) => {
     if (width > 768) {
       setIsMenuOpen(false);
     }
-  }, [width]);
+    if (height > 720) {
+      setIsMenuOpen(false);
+    }
+  }, [width, height]);
 
   return (
     <>

--- a/src/components/button/NavigationButton.module.scss
+++ b/src/components/button/NavigationButton.module.scss
@@ -68,9 +68,6 @@ $btn-l: 80px;
   }
 }
 
-@media screen and (max-height: 720px) {
-  @include navButtonXl;
-}
 @include mediaQuery('xl') {
   @include navButtonXl;
 }
@@ -102,5 +99,12 @@ $btn-l: 80px;
 @include mediaQuery('sm') {
   .current {
     top: 98px;
+  }
+}
+@media screen and (max-height: 720px) {
+  @include navButtonXl;
+  .current {
+    left: calc(50% - 4px);
+    top: 104px;
   }
 }


### PR DESCRIPTION
タブレットサイズでメニューOpen時は上下中央に配置。
スマホサイズでメニューOpen時は上に揃えて配置(スマホアプリが上揃えになるみたいに)。