### PR TITLE
fix: sectionなどのタグ付けをより適切な方法に修正

### DIFF
--- a/src/components/Hero.module.scss
+++ b/src/components/Hero.module.scss
@@ -1,6 +1,6 @@
 @import '../styles/variables.scss';
 
-.section {
+.container {
   text-align: center;
   padding: 160px 0;
 }
@@ -13,7 +13,12 @@
   padding-bottom: 0.7em;
   @include transition_spacing;
 }
-.role {
+.hidden {
+  position: absolute;
+  top: -9999px;
+  left: -9999px;
+}
+.occupation {
   font-size: clamp(1.4rem, 2vw, 2.4rem);
   font-family: 'Roboto Condensed', sans-serif;
   font-weight: 400;

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -11,14 +11,17 @@ type Props = { content: string };
 
 const Hero: NextPage<Props> = ({ content }) => {
   return (
-    <section className={styles.section}>
+    <div className={styles.container}>
       <h1 className={`${cormorantGaramond.className} ${styles.name}`}>
         Tatsuya
         <br />
         Hasegawa
       </h1>
-      <p className={`${styles.role} ${robotoCondensed.className}`}>{content}</p>
-    </section>
+      <section>
+        <h2 className={styles.hidden}>職種</h2>
+        <p className={`${styles.occupation} ${robotoCondensed.className}`}>{content}</p>
+      </section>
+    </div>
   );
 };
 

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -42,7 +42,7 @@ const Layout = ({ children }: { children: ReactNode }) => {
           <div className={styles.layout}>
             <div className={styles.glassContainer}>
               <div
-                className={`${isMenuOpen === true ? styles.header__menuOpen : ''} ${styles.header}`}
+                className={`${styles.header} ${isMenuOpen === true ? styles.header__menuOpen : ''}`}
               >
                 <Header />
               </div>

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -61,7 +61,7 @@ const About = () => {
       />
       <div className={notoSansJP.className}>
         <Layout>
-          <section className={styles.section}>
+          <div className={styles.section}>
             <div className={styles.ttl_container}>
               <h1 className={`${caveat.className} ${styles.main_ttl}`}>About</h1>
               <p className={styles.sub_ttl}>私について</p>
@@ -118,7 +118,7 @@ const About = () => {
                 ))}
               </section>
             ))}
-          </section>
+          </div>
         </Layout>
       </div>
     </>

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -61,7 +61,7 @@ const About = () => {
       />
       <div className={notoSansJP.className}>
         <Layout>
-          <div className={styles.section}>
+          <div className={styles.container}>
             <div className={styles.ttl_container}>
               <h1 className={`${caveat.className} ${styles.main_ttl}`}>About</h1>
               <p className={styles.sub_ttl}>私について</p>

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -79,28 +79,28 @@ const About = () => {
                 <h2 className={`${notoSansJP.className} ${styles.profile__name}`}>
                   {profile.name}
                 </h2>
-                <ul className={styles.profile__txt}>
-                  <li className={styles.profile__li}>
-                    <span className={styles.profile__ttl}>所属</span>
-                    <span className={styles.profile__content}>{profile.team}</span>
-                  </li>
-                  <li className={styles.profile__li}>
-                    <span className={styles.profile__ttl}>生年月日</span>
-                    <span className={styles.profile__content}>{profile.birth}</span>
-                  </li>
-                  <li className={styles.profile__li}>
-                    <span className={styles.profile__ttl}>趣味</span>
-                    <span className={styles.profile__content}>{profile.hobby}</span>
-                  </li>
-                  <li className={styles.profile__li}>
-                    <span className={styles.profile__ttl}>好きな食べ物</span>
-                    <span className={styles.profile__content}>{profile.favoriteFood}</span>
-                  </li>
-                  <li className={styles.profile__li}>
-                    <span className={styles.profile__ttl}>開発経験</span>
-                    <span className={styles.profile__content}>{profile.experience}</span>
-                  </li>
-                </ul>
+                <dl className={styles.profile__txt}>
+                  <div className={styles.profile__li}>
+                    <dt className={styles.profile__ttl}>所属</dt>
+                    <dd className={styles.profile__content}>{profile.team}</dd>
+                  </div>
+                  <div className={styles.profile__li}>
+                    <dt className={styles.profile__ttl}>生年月日</dt>
+                    <dd className={styles.profile__content}>{profile.birth}</dd>
+                  </div>
+                  <div className={styles.profile__li}>
+                    <dt className={styles.profile__ttl}>趣味</dt>
+                    <dd className={styles.profile__content}>{profile.hobby}</dd>
+                  </div>
+                  <div className={styles.profile__li}>
+                    <dt className={styles.profile__ttl}>好きな食べ物</dt>
+                    <dd className={styles.profile__content}>{profile.favoriteFood}</dd>
+                  </div>
+                  <div className={styles.profile__li}>
+                    <dt className={styles.profile__ttl}>開発経験</dt>
+                    <dd className={styles.profile__content}>{profile.experience}</dd>
+                  </div>
+                </dl>
               </div>
             </section>
             {contents.map((content) => (

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -116,7 +116,7 @@ const Contact = () => {
         pageDescription=""
       />
       <Layout>
-        <section className={styles.section}>
+        <div className={styles.section}>
           <div className={styles.ttl_container}>
             <h1 className={`${caveat.className} ${styles.main_ttl}`}>Contact</h1>
             <p className={styles.sub_ttl}>お問い合わせ</p>
@@ -182,7 +182,7 @@ const Contact = () => {
               </>
             </button>
           </form>
-        </section>
+        </div>
       </Layout>
       <ToastContainer />
     </>

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -116,7 +116,7 @@ const Contact = () => {
         pageDescription=""
       />
       <Layout>
-        <div className={styles.section}>
+        <div className={styles.container}>
           <div className={styles.ttl_container}>
             <h1 className={`${caveat.className} ${styles.main_ttl}`}>Contact</h1>
             <p className={styles.sub_ttl}>お問い合わせ</p>

--- a/src/pages/contact/thanks.tsx
+++ b/src/pages/contact/thanks.tsx
@@ -37,22 +37,27 @@ const Thanks = () => {
                   className={styles.thanks__icon}
                 />
               </div>
-              <p className={styles.thanks__message}>
-                お問い合わせありがとうございます。
-                <br />
-                ご入力いただいたメールアドレス宛に自動返信メールを配信しております。
-                <br />
-                完了メールが届かない場合、処理が正常に行われていない可能性があります。
-                <br />
-                大変お手数ですが、再度お問い合わせの手続きをお願い致します。
-              </p>
-              <p className={`${caveat.className} ${styles.thanks__name}`}>Tatsuya Hasegawa</p>
-              <p className={styles.thanks__linkContainer}>
-                <Link href="/" className={styles.thanks__link}>
-                  <FontAwesomeIcon icon={faHome} className={styles.thanks__eyecatch} />
-                  <span>HOMEへ戻る</span>
-                </Link>
-              </p>
+              <section>
+                <h2 className={styles.hidden}>お問い合わせ完了メッセージ</h2>
+                <p className={styles.thanks__message}>
+                  お問い合わせありがとうございます。
+                  <br />
+                  ご入力いただいたメールアドレス宛に自動返信メールを配信しております。
+                  <br />
+                  <strong>
+                    完了メールが届かない場合、処理が正常に行われていない可能性があります。
+                  </strong>
+                  <br />
+                  大変お手数ですが、再度お問い合わせの手続きをお願い致します。
+                </p>
+                <p className={`${caveat.className} ${styles.thanks__name}`}>Tatsuya Hasegawa</p>
+                <p className={styles.thanks__linkContainer}>
+                  <Link href="/" className={styles.thanks__link}>
+                    <FontAwesomeIcon icon={faHome} className={styles.thanks__eyecatch} />
+                    <span>HOMEへ戻る</span>
+                  </Link>
+                </p>
+              </section>
             </div>
           </div>
         </div>

--- a/src/pages/contact/thanks.tsx
+++ b/src/pages/contact/thanks.tsx
@@ -22,7 +22,7 @@ const Thanks = () => {
       />
       <Layout>
         <div className={notoSansJP.className}>
-          <div className={styles.section}>
+          <div className={styles.container}>
             <div className={styles.ttl_container}>
               <h1 className={`${caveat.className} ${styles.main_ttl}`}>Thanks</h1>
               <p className={styles.sub_ttl}>お問い合わせ完了</p>

--- a/src/pages/contact/thanks.tsx
+++ b/src/pages/contact/thanks.tsx
@@ -22,7 +22,7 @@ const Thanks = () => {
       />
       <Layout>
         <div className={notoSansJP.className}>
-          <section className={styles.section}>
+          <div className={styles.section}>
             <div className={styles.ttl_container}>
               <h1 className={`${caveat.className} ${styles.main_ttl}`}>Thanks</h1>
               <p className={styles.sub_ttl}>お問い合わせ完了</p>
@@ -54,7 +54,7 @@ const Thanks = () => {
                 </Link>
               </p>
             </div>
-          </section>
+          </div>
         </div>
       </Layout>
     </>

--- a/src/pages/works.tsx
+++ b/src/pages/works.tsx
@@ -24,7 +24,7 @@ const Works: NextPage<Works> = ({ works }) => {
       />
       <div className={notoSansJP.className}>
         <Layout>
-          <div className={styles.section}>
+          <div className={styles.container}>
             <div className={styles.ttl_container}>
               <h1 className={`${caveat.className} ${styles.main_ttl}`}>Works</h1>
               <p className={styles.sub_ttl}>過去の制作物</p>

--- a/src/pages/works.tsx
+++ b/src/pages/works.tsx
@@ -24,7 +24,7 @@ const Works: NextPage<Works> = ({ works }) => {
       />
       <div className={notoSansJP.className}>
         <Layout>
-          <section className={styles.section}>
+          <div className={styles.section}>
             <div className={styles.ttl_container}>
               <h1 className={`${caveat.className} ${styles.main_ttl}`}>Works</h1>
               <p className={styles.sub_ttl}>過去の制作物</p>
@@ -43,7 +43,7 @@ const Works: NextPage<Works> = ({ works }) => {
                 </Link>
               </div>
             ))}
-          </section>
+          </div>
         </Layout>
       </div>
     </>

--- a/src/pages/works/[id].tsx
+++ b/src/pages/works/[id].tsx
@@ -31,68 +31,70 @@ const WorkId: NextPage<Work> = (work) => {
       />
       <div className={notoSansJP.className}>
         <Layout>
-          <section className={styles.section}>
+          <div className={styles.section}>
             <div className={styles.ttl_container}>
               <h1 className={`${caveat.className} ${styles.main_ttl}`}>Work</h1>
               <p className={styles.sub_ttl}>制作物の詳細</p>
             </div>
-            <div className={styles.thumbnailContainer}>
-              <Image
-                src={work.thumbnail.url}
-                width={work.thumbnail.width}
-                height={work.thumbnail.height}
-                alt={work.name}
-                className={styles.thumbnail}
-                priority
-              />
-            </div>
-            <section className={styles.contentContainer}>
-              <div className={styles.nameContainer}>
-                <p className={styles.date}>{work.date}</p>
-                <h2 className={styles.name}>{work.name}</h2>
+            <section>
+              <div className={styles.thumbnailContainer}>
+                <Image
+                  src={work.thumbnail.url}
+                  width={work.thumbnail.width}
+                  height={work.thumbnail.height}
+                  alt={work.name}
+                  className={styles.thumbnail}
+                  priority
+                />
               </div>
-              <section
-                className={`${
-                  work.icon?.url ? styles.detailContainer : styles.detailContainer__NoIcon
-                }`}
-              >
-                <section className={styles.detail}>
-                  {items.map((item) => (
-                    <div key={item.title} className={styles.detail__box}>
-                      <h3 className={styles.detail__ttl}>{item.title}</h3>
-                      {item.value === work.url ? (
-                        <p className={styles.detail__txt}>
-                          <Link href={item.value} target="_blank" className={styles.detail__url}>
-                            {item.value}
-                          </Link>
-                        </p>
-                      ) : (
-                        <p className={styles.detail__txt}>{item.value}</p>
-                      )}
-                    </div>
-                  ))}
-                </section>
-                {work.icon && work.shortName ? (
-                  <section className={styles.work}>
-                    <Link href={work.url} target="_blank">
-                      <div className={styles.work__iconWrap}>
-                        <Image
-                          src={work.icon.url}
-                          width={work.icon.width}
-                          height={work.icon.height}
-                          alt={work.shortName}
-                          className={styles.work__icon}
-                        />
+              <div className={styles.contentContainer}>
+                <div className={styles.nameContainer}>
+                  <p className={styles.date}>{work.date}</p>
+                  <h2 className={styles.name}>{work.name}</h2>
+                </div>
+                <div
+                  className={`${
+                    work.icon?.url ? styles.detailContainer : styles.detailContainer__NoIcon
+                  }`}
+                >
+                  <dl className={styles.detail}>
+                    {items.map((item) => (
+                      <div key={item.title} className={styles.detail__box}>
+                        <dt className={styles.detail__ttl}>{item.title}</dt>
+                        {item.value === work.url ? (
+                          <dd className={styles.detail__txt}>
+                            <Link href={item.value} target="_blank" className={styles.detail__url}>
+                              {item.value}
+                            </Link>
+                          </dd>
+                        ) : (
+                          <dd className={styles.detail__txt}>{item.value}</dd>
+                        )}
                       </div>
-                    </Link>
-                    <h3 className={styles.work__shortName}>{work.shortName}</h3>
-                  </section>
-                ) : (
-                  ''
-                )}
-              </section>
+                    ))}
+                  </dl>
+                  {work.icon && work.shortName ? (
+                    <figure className={styles.work}>
+                      <Link href={work.url} target="_blank">
+                        <div className={styles.work__iconWrap}>
+                          <Image
+                            src={work.icon.url}
+                            width={work.icon.width}
+                            height={work.icon.height}
+                            alt={work.shortName}
+                            className={styles.work__icon}
+                          />
+                        </div>
+                      </Link>
+                      <figcaption className={styles.work__shortName}>{work.shortName}</figcaption>
+                    </figure>
+                  ) : (
+                    ''
+                  )}
+                </div>
+              </div>
             </section>
-          </section>
+          </div>
         </Layout>
       </div>
     </>

--- a/src/styles/about.module.scss
+++ b/src/styles/about.module.scss
@@ -1,6 +1,6 @@
 @import './variables.scss';
 
-.section {
+.container {
   @include section;
   @include transition_spacing;
 }

--- a/src/styles/contact-thanks.module.scss
+++ b/src/styles/contact-thanks.module.scss
@@ -1,6 +1,6 @@
 @import './variables.scss';
 
-.section {
+.container {
   @include section;
   @include transition_spacing;
 }

--- a/src/styles/contact-thanks.module.scss
+++ b/src/styles/contact-thanks.module.scss
@@ -17,6 +17,11 @@
   @include transition_text;
 }
 
+.hidden {
+  position: absolute;
+  top: -9999px;
+  left: -9999px;
+}
 .thanks {
   text-align: center;
   &__iconContainer {

--- a/src/styles/contact.module.scss
+++ b/src/styles/contact.module.scss
@@ -18,7 +18,7 @@ $formBorderRadius: 6px;
   }
 }
 
-.section {
+.container {
   @include section;
   @include transition_spacing;
 }

--- a/src/styles/works.module.scss
+++ b/src/styles/works.module.scss
@@ -1,6 +1,6 @@
 @import './variables.scss';
 
-.section {
+.container {
   @include section;
   @include transition_spacing;
 }


### PR DESCRIPTION
より適切なタグの使い方に修正を行いました。

・h1をsectionで囲んでしまっていたところを修正しました
・キーと値がペアになっているような説明リストを適切なタグ(dl)に修正しました
・お問い合わせ完了を伝えるメッセージの中で、重要な要素は適切にタグ(strong)に修正しました
・例外的に見出しのないセクションには、画面リーダーのような支援技術のユーザーを考慮し、視覚的には存在しなくても要素としては存在するように修正しました